### PR TITLE
Add Spawning Rules for Thompson Magazines

### DIFF
--- a/CVARINFO
+++ b/CVARINFO
@@ -1,36 +1,46 @@
 
 // Bronto-Buddy
-server bool brontobuddy_allowBackpacks          = true;
-server int  brontobuddy_spawn_bias              = 4;
-server bool brontobuddy_persistent_spawning     = false;
+server bool brontobuddy_allowBackpacks               = true;
+server int  brontobuddy_spawn_bias                   = 4;
+server bool brontobuddy_persistent_spawning          = false;
 
 // Khleb Pump-Action Shotgun
-server bool khleb_allowBackpacks                = false;
-server int  khleb_spawn_bias                    = -1;
-server bool khleb_persistent_spawning           = false;
+server bool khleb_allowBackpacks                     = false;
+server int  khleb_spawn_bias                         = -1;
+server bool khleb_persistent_spawning                = false;
 
 // Reaper Auto-Shotgun
-server bool reaper_allowBackpacks               = true;
-server int  reaper_hunter_spawn_bias            = 19;
-server int  reaper_slayer_spawn_bias            = 19;
-server bool reaper_persistent_spawning          = false;
+server bool reaper_allowBackpacks                    = true;
+server int  reaper_hunter_spawn_bias                 = 19;
+server int  reaper_slayer_spawn_bias                 = 19;
+server bool reaper_persistent_spawning               = false;
 
 // Thompson
-server bool thompson_allowBackpacks             = true;
-server int  thompson_chaingun_spawn_bias        = 24;
-server bool thompson_persistent_spawning        = false;
+server bool thompson_allowBackpacks                  = true;
+server int  thompson_chaingun_spawn_bias             = 24;
+server bool thompson_persistent_spawning             = false;
 
 // Reaper 8-round Magazine
-server bool reapermag_allowBackpacks            = true;
-server int  reapermag_shellbox_spawn_bias       = 19;
-server bool reapermag_persistent_spawning       = false;
+server bool reapermag_allowBackpacks                 = true;
+server int  reapermag_shellbox_spawn_bias            = 19;
+server bool reapermag_persistent_spawning            = false;
 
 // Reaper 20-round Drum Magazine
-server bool reaperdrummag_allowBackpacks        = true;
-server int  reaperdrummag_shellbox_spawn_bias   = 19;
-server bool reaperdrummag_persistent_spawning   = false;
+server bool reaperdrummag_allowBackpacks             = true;
+server int  reaperdrummag_shellbox_spawn_bias        = 19;
+server bool reaperdrummag_persistent_spawning        = false;
 
-// Thompson 70-round Drum Magazine
-server bool thompsondrummag_allowBackpacks      = true;
-server int  thompsondrummag_clipmag_spawn_bias  = 29;
-server bool thompsondrummag_persistent_spawning = false;
+// Thompson 70-round 9x22mm Drum Magazine
+server bool thompsondrummag_allowBackpacks           = true;
+server int  thompsondrummag_clipmag_spawn_bias       = 29;
+server bool thompsondrummag_persistent_spawning      = false;
+
+// Thompson 50-round .45 ACP Drum Magazine
+server bool thompson45acpdrummag_allowBackpacks      = true;
+server int  thompson45acpdrummag_clipmag_spawn_bias  = 29;
+server bool thompson45acpdrummag_persistent_spawning = false;
+
+// Thompson 20-round .45 ACP Box Magazine
+server bool thompsonboxmag_allowBackpacks            = true;
+server int  thompsonboxmag_clipmag_spawn_bias        = 29;
+server bool thompsonboxmag_persistent_spawning       = false;

--- a/LANGUAGE
+++ b/LANGUAGE
@@ -1,120 +1,114 @@
 [en default]
 
-TAG_BRONTOBUDDY                        = "Brontornis Cannon W/Bolt Rack";
-TAG_KHLEB                              = "Khleb";
-TAG_REAPER                             = "Reaper Automatic Shotgun";
-TAG_THOMPSON                           = "Thompson Submachine Gun";
-TAG_THOMPSON_NINEMIL                   = "Thompson Submachine Gun (9mm Repro)";
+TAG_BRONTOBUDDY                             = "Brontornis Cannon W/Bolt Rack";
+TAG_KHLEB                                   = "Khleb";
+TAG_REAPER                                  = "Reaper Automatic Shotgun";
+TAG_THOMPSON                                = "Thompson Submachine Gun";
+TAG_THOMPSON_NINEMIL                        = "Thompson Submachine Gun (9mm Repro)";
 
-TAG_REAPER_MAG                         = "Reaper Magazine";
-TAG_REAPER_DRUMMAG                     = "Reaper Drum";
-TAG_THOMPSON_DRUMMAG                   = "Thompson Drum (9mm Repro)";
-TAG_THOMPSON_45ACPDRUMMAG              = "Thompson Drum";
-TAG_THOMPSON_45ACPBOXMAG               = "Thompson Drum";
+TAG_REAPER_MAG                              = "Reaper Magazine";
+TAG_REAPER_DRUMMAG                          = "Reaper Drum";
+TAG_THOMPSON_DRUMMAG                        = "Thompson Drum (9mm Repro)";
+TAG_THOMPSON_45ACPDRUMMAG                   = "Thompson Drum";
+TAG_THOMPSON_45ACPBOXMAG                    = "Thompson Drum";
 
-PICKUP_BRONTOBUDDY                     = "You got the Brontornis! It's got a neat bolt rack!";
-PICKUP_KHLEB                           = "It's Khleb-bering time!";
-PICKUP_REAPER                          = "You got the Reaper Automatic Shotgun!";
-PICKUP_REAPER_GL                       = "You got the Reaper Automatic Shotgun! This one has an underbarrel Grenade Launcher!";
-PICKUP_REAPER_ZM                       = "You got the Reaper Automatic Shotgun! This one has an underbarrel Carbine!";
-PICKUP_THOMPSON                        = "You got the Thompson SMG! Rata-tat-tat!";
-PICKUP_THOMPSON_NINEMIL                = "You got the Thompson SMG! This one's a reproduction...";
+PICKUP_BRONTOBUDDY                          = "You got the Brontornis! It's got a neat bolt rack!";
+PICKUP_KHLEB                                = "It's Khleb-bering time!";
+PICKUP_REAPER                               = "You got the Reaper Automatic Shotgun!";
+PICKUP_REAPER_GL                            = "You got the Reaper Automatic Shotgun! This one has an underbarrel Grenade Launcher!";
+PICKUP_REAPER_ZM                            = "You got the Reaper Automatic Shotgun! This one has an underbarrel Carbine!";
+PICKUP_THOMPSON                             = "You got the Thompson SMG! Rata-tat-tat!";
+PICKUP_THOMPSON_NINEMIL                     = "You got the Thompson SMG! This one's a reproduction...";
 
-PICKUP_REAPER_MAG                      = "Picked up a 12 Gauge Magazine.";
-PICKUP_REAPER_DRUMMAG                  = "Picked up a 12 Gauge Drum Magazine.";
-PICKUP_THOMPSON_DRUMMAG                = "Picked up a 9mm Drum magazine.";
-PICKUP_THOMPSON_45ACPDRUMMAG           = "Picked up a .45 ACP Drum magazine.";
-PICKUP_THOMPSON_45ACPBOXMAG            = "Picked up a .45 ACP magazine.";
+PICKUP_REAPER_MAG                           = "Picked up a 12 Gauge Magazine.";
+PICKUP_REAPER_DRUMMAG                       = "Picked up a 12 Gauge Drum Magazine.";
+PICKUP_THOMPSON_DRUMMAG                     = "Picked up a 9mm Drum magazine.";
+PICKUP_THOMPSON_45ACPDRUMMAG                = "Picked up a .45 ACP Drum magazine.";
+PICKUP_THOMPSON_45ACPBOXMAG                 = "Picked up a .45 ACP magazine.";
 
-OB_KHLEB                               = "%k pyhiscally removed a chunk of %o and threw that s#&! on the floor";
-OB_REAPER                              = "%k called a %o harvest.";
-OB_THOMPSON                            = "%o found out what was in %k's violin case.";
+OB_KHLEB                                    = "%k pyhiscally removed a chunk of %o and threw that s#&! on the floor";
+OB_REAPER                                   = "%k called a %o harvest.";
+OB_THOMPSON                                 = "%o found out what was in %k's violin case.";
 
 // Menu Labels
 
 // Options Menu Titles
-RRRR_MENU                              = "\c[Fire]Ⓡ\c- RightInfinity's Revolting Revolutionary Rweapons";
-MENU_SHOTGUNS_TITLE                    = "--- Shotguns ---";
-MENU_MACHINEGUNS_TITLE                 = "--- Machine Guns ---";
-MENU_RIFLES_TITLE                      = "--- Rifles ---";
-MENU_RESETOPTIONS_TITLE                = "--- Reset Options ---";
+RRRR_MENU                                   = "\c[Fire]Ⓡ\c- RightInfinity's Revolting Revolutionary Rweapons";
+MENU_SHOTGUNS_TITLE                         = "--- Shotguns ---";
+MENU_MACHINEGUNS_TITLE                      = "--- Machine Guns ---";
+MENU_RIFLES_TITLE                           = "--- Rifles ---";
+MENU_RESETOPTIONS_TITLE                     = "--- Reset Options ---";
 
 // Menu Section Headers
-MENU_SPAWNOPTIONS                      = "Spawn Options";
-MENU_WEPSPAWNOPTIONS                   = "Weapon Spawn Options";
-MENU_MAGSPAWNOPTIONS                   = "Magazine Spawn Options";
-MENU_PERSISTENCYOPTIONS                = "Spawn Persistence Options";
-MENU_RESETOPTIONS                      = "Reset Options";
-MENU_RESETALLOPTIONS                   = "Reset all Options";
+MENU_SPAWNOPTIONS                           = "Spawn Options";
+MENU_WEPSPAWNOPTIONS                        = "Weapon Spawn Options";
+MENU_MAGSPAWNOPTIONS                        = "Magazine Spawn Options";
+MENU_PERSISTENCYOPTIONS                     = "Spawn Persistence Options";
+MENU_RESETOPTIONS                           = "Reset Options";
+MENU_RESETALLOPTIONS                        = "Reset all Options";
 
 // Menu Static Text
-MENU_SPAWNRATE_TEXT1                   = "Setting 'spawn rate' to Replace All will suppress";
-MENU_SPAWNRATE_TEXT2                   = "spawns of that given type.";
-MENU_PERSISTENCY_TEXT                  = "Control whether replacements happen after a mapload:";
+MENU_SPAWNRATE_TEXT1                        = "Setting 'spawn rate' to Replace All will suppress";
+MENU_SPAWNRATE_TEXT2                        = "spawns of that given type.";
+MENU_PERSISTENCY_TEXT                       = "Control whether replacements happen after a mapload:";
 
 // Menu Option Labels
-MENU_NOTICE                            = "Notice:";
-MENU_BACKPACKSALLOWED                  = "Allowed in Ammo Boxes and/or Backpacks: ";
-MENU_SPAWNRATE                         = "Spawn Rate: ";
-MENU_WEPSPAWNRATE                      = "Weapon Spawn Rate: ";
-MENU_MAGSPAWNRATE                      = "Magazine Spawn Rate: ";
-MENU_PERSISTENCY                       = "Persistent Spawns: ";
-MENU_WEPPERSISTENCY                    = "Persistent Weapon Spawns: ";
-MENU_MAGPERSISTENCY                    = "Persistent Magazine Spawns: ";
+MENU_NOTICE                                 = "Notice:";
+MENU_BACKPACKSALLOWED                       = "Allowed in Ammo Boxes and/or Backpacks: ";
+MENU_SPAWNRATE                              = "Spawn Rate: ";
+MENU_WEPSPAWNRATE                           = "Weapon Spawn Rate: ";
+MENU_MAGSPAWNRATE                           = "Magazine Spawn Rate: ";
+MENU_PERSISTENCY                            = "Persistent Spawns: ";
+MENU_WEPPERSISTENCY                         = "Persistent Weapon Spawns: ";
+MENU_MAGPERSISTENCY                         = "Persistent Magazine Spawns: ";
 
 // Menu Option Values
-MENU_ENABLED                           = "Enabled";
-MENU_DISABLED                          = "Disabled";
-MENU_REPLACEALL                        = "Replace All";
-MENU_WITHALL                           = "With All";
+MENU_ENABLED                                = "Enabled";
+MENU_DISABLED                               = "Disabled";
+MENU_REPLACEALL                             = "Replace All";
+MENU_WITHALL                                = "With All";
 
 // Menu Command Text
-MENU_RESETWEP                          = "Reset Weapon Options";
-MENU_RESETMAG                          = "Reset Magazine Options";
-MENU_RESETPERSISTENCY                  = "Reset Persistence Options";
-RRRR_RESETALLOPTIONS                   = "Reset all options for RightInfinity's Revolting Revolutionary Rweapons";
+MENU_RESETWEP                               = "Reset Weapon Options";
+MENU_RESETMAG                               = "Reset Magazine Options";
+MENU_RESETPERSISTENCY                       = "Reset Persistence Options";
+RRRR_RESETALLOPTIONS                        = "Reset all options for RightInfinity's Revolting Revolutionary Rweapons";
 
 // Khleb Options Text
-MENU_KHLEB_TITLE                       = "------ Khleb Options ------";
-MENU_KHLEB_SPAWNTEXT                   = "Control the spawn rate of the Khleb on Hunter Shotguns:";
-MENU_KHLEB_BACKPACKS                   = "Control whether the Khleb spawns in Backpacks:";
-
-// Frontiersman Options Text
-MENU_FRONTIERSMAN_TITLE                = "------ 'Frontiersman' 7.76mm Lever-Action Rifle Options ------";
-MENU_FRONTIERSMAN_HUNTER_SPAWNTEXT     = "Control the spawn rate of the Frontiersman on Hunter Shotguns:";
-MENU_FRONTIERSMAN_SLAYER_SPAWNTEXT     = "Control the spawn rate of the Frontiersman on Slayer Shotguns:";
-MENU_FRONTIERSMAN_BACKPACKS            = "Control whether the Frontiersman spawns in Backpacks:";
-
-// GFB-9 Options Text
-MENU_GFB9_TITLE                        = "------ Gretchenfrage Blaster Mk. 9 Options ------";
-MENU_GFB9_PISTOL_SPAWNTEXT             = "Control the spawn rate of the GFB-9 on Pistols:";
-MENU_GFB9_CLIPBOX_SPAWNTEXT            = "Control the spawn rate of the GFB-9 on Clip Boxes:";
-MENU_GFB9_BACKPACKS                    = "Control whether the GFB-9 spawns in Backpacks:";
+MENU_KHLEB_TITLE                            = "------ Khleb Options ------";
+MENU_KHLEB_SPAWNTEXT                        = "Control the spawn rate of the Khleb on Hunter Shotguns:";
+MENU_KHLEB_BACKPACKS                        = "Control whether the Khleb spawns in Backpacks:";
 
 // Bronto-Buddy Options Text
-MENU_BRONTOBUDDY_TITLE                 = "------ Bronto-Buddy Options ------";
-MENU_BRONTOBUDDY_SPAWNTEXT             = "Control the spawn rate of the Bronto-Buddy on Brontornis:";
-MENU_BRONTOBUDDY_BACKPACKS             = "Control whether the Bronto-Buddy spawns in Backpacks:";
+MENU_BRONTOBUDDY_TITLE                      = "------ Bronto-Buddy Options ------";
+MENU_BRONTOBUDDY_SPAWNTEXT                  = "Control the spawn rate of the Bronto-Buddy on Brontornis:";
+MENU_BRONTOBUDDY_BACKPACKS                  = "Control whether the Bronto-Buddy spawns in Backpacks:";
 
 // Reaper Options Text
-MENU_REAPER_TITLE                      = "------ Reaper Options ------";
-MENU_REAPER_HUNTER_SPAWNTEXT           = "Control the spawn rate of the Reaper on Hunter Shotguns:";
-MENU_REAPER_SLAYER_SPAWNTEXT           = "Control the spawn rate of the Reaper on Slayer Shotguns:";
-MENU_REAPER_BACKPACKS                  = "Control whether the Reaper spawns in Backpacks:";
+MENU_REAPER_TITLE                           = "------ Reaper Options ------";
+MENU_REAPER_HUNTER_SPAWNTEXT                = "Control the spawn rate of the Reaper on Hunter Shotguns:";
+MENU_REAPER_SLAYER_SPAWNTEXT                = "Control the spawn rate of the Reaper on Slayer Shotguns:";
+MENU_REAPER_BACKPACKS                       = "Control whether the Reaper spawns in Backpacks:";
 
-MENU_REAPERMAG_SHELLBOX_SPAWNTEXT      = "Control the spawn rate of Reaper Shell Magazines on Shell Box Pickups:";
-MENU_REAPERMAG_BACKPACKS               = "Control whether Reaper Shell Magazines spawn in Backpacks:";
+MENU_REAPERMAG_SHELLBOX_SPAWNTEXT           = "Control the spawn rate of Reaper Shell Magazines on Shell Box Pickups:";
+MENU_REAPERMAG_BACKPACKS                    = "Control whether Reaper Shell Magazines spawn in Backpacks:";
 
-MENU_REAPERDRUMMAG_SHELLBOX_SPAWNTEXT  = "Control the spawn rate of Reaper Shell Drum Magazines on Shell Box Pickups:";
-MENU_REAPERDRUMMAG_BACKPACKS           = "Control whether Reaper Shell Drum Magazines spawn in Backpacks:";
+MENU_REAPERDRUMMAG_SHELLBOX_SPAWNTEXT       = "Control the spawn rate of Reaper Shell Drum Magazines on Shell Box Pickups:";
+MENU_REAPERDRUMMAG_BACKPACKS                = "Control whether Reaper Shell Drum Magazines spawn in Backpacks:";
 
-MENU_REAPERMAG_PERSISTENCY             = "Persistent Shell Magazine Spawns: ";
-MENU_REAPERDRUMMAG_PERSISTENCY         = "Persistent Shell Drum Magazine Spawns: ";
+MENU_REAPERMAG_PERSISTENCY                  = "Persistent Shell Magazine Spawns: ";
+MENU_REAPERDRUMMAG_PERSISTENCY              = "Persistent Shell Drum Magazine Spawns: ";
 
 // THOMPSON Options Text
-MENU_THOMPSON_TITLE                    = "------ Thompson Options ------";
-MENU_THOMPSON_CHAINGUN_SPAWNTEXT       = "Control the spawn rate of the Thompson on Vulcanettes:";
-MENU_THOMPSON_BACKPACKS                = "Control whether the Thompson spawns in Backpacks:";
+MENU_THOMPSON_TITLE                         = "------ Thompson Options ------";
+MENU_THOMPSON_CHAINGUN_SPAWNTEXT            = "Control the spawn rate of the Thompson on Vulcanettes:";
+MENU_THOMPSON_BACKPACKS                     = "Control whether the Thompson spawns in Backpacks:";
 
-MENU_THOMPSONDRUMMAG_CLIPMAG_SPAWNTEXT = "Control the spawn rate of Thompson Drum Magazines on Clip Magazines:";
-MENU_THOMPSONDRUMMAG_BACKPACKS         = "Control whether Thompson Drum Magazines spawn in Backpacks:";
+MENU_THOMPSONDRUMMAG_CLIPMAG_SPAWNTEXT      = "Control the spawn rate of Thompson 9x22mm Drum Magazines on Clip Magazines:";
+MENU_THOMPSONDRUMMAG_BACKPACKS              = "Control whether Thompson 9x22mm Drum Magazines spawn in Backpacks:";
+
+MENU_THOMPSON45ACPDRUMMAG_CLIPMAG_SPAWNTEXT = "Control the spawn rate of Thompson .45 ACP Drum Magazines on Clip Magazines:";
+MENU_THOMPSON45ACPDRUMMAG_BACKPACKS         = "Control whether Thompson .45 ACP Drum Magazines spawn in Backpacks:";
+
+MENU_THOMPSONBOXMAG_CLIPMAG_SPAWNTEXT       = "Control the spawn rate of Thompson .45 ACP Box Magazines on Clip Magazines:";
+MENU_THOMPSONBOXMAG_BACKPACKS               = "Control whether Thompson .45 ACP Box Magazines spawn in Backpacks:";

--- a/MENUDEF
+++ b/MENUDEF
@@ -139,13 +139,31 @@ OptionMenu "thompsonSpawning" {
  	StaticText ""
 
 	StaticText "$MENU_MAGSPAWNOPTIONS", "Green"
-    StaticText "$MENU_THOMPSONDRUMMAG_CLIPMAG_SPAWNTEXT", "White"
+    /* StaticText "$MENU_THOMPSONDRUMMAG_CLIPMAG_SPAWNTEXT", "White"
 	ScaleSlider "$MENU_MAGSPAWNRATE", "thompsondrummag_clipmag_spawn_bias", -1, 999, 1, "$MENU_REPLACEALL", "$MENU_DISABLED"
 	SafeCommand "$MENU_RESETMAG", "resetcvar thompsondrummag_clipmag_spawn_bias"
- 	StaticText ""
+	StaticText ""
 
 	StaticText "$MENU_THOMPSONDRUMMAG_BACKPACKS", "White"
 	Option "$MENU_BACKPACKSALLOWED", "thompsondrummag_allowBackpacks", "OnOff"
+ 	StaticText "" */
+
+    StaticText "$MENU_THOMPSON45ACPDRUMMAG_CLIPMAG_SPAWNTEXT", "White"
+	ScaleSlider "$MENU_MAGSPAWNRATE", "thompson45acpdrummag_clipmag_spawn_bias", -1, 999, 1, "$MENU_REPLACEALL", "$MENU_DISABLED"
+	SafeCommand "$MENU_RESETMAG", "resetcvar thompson45acpdrummag_clipmag_spawn_bias"
+ 	StaticText ""
+
+	StaticText "$MENU_THOMPSON45ACPDRUMMAG_BACKPACKS", "White"
+	Option "$MENU_BACKPACKSALLOWED", "thompson45acpdrummag_allowBackpacks", "OnOff"
+ 	StaticText ""
+	
+	StaticText "$MENU_THOMPSONBOXMAG_CLIPMAG_SPAWNTEXT", "White"
+	ScaleSlider "$MENU_MAGSPAWNRATE", "thompsonboxmag_clipmag_spawn_bias", -1, 999, 1, "$MENU_REPLACEALL", "$MENU_DISABLED"
+	SafeCommand "$MENU_RESETMAG", "resetcvar thompsonboxmag_clipmag_spawn_bias"
+	StaticText ""
+
+	StaticText "$MENU_THOMPSONBOXMAG_BACKPACKS", "White"
+	Option "$MENU_BACKPACKSALLOWED", "thompsonboxmag_allowBackpacks", "OnOff"
  	StaticText ""
 
 	StaticText "$MENU_PERSISTENCYOPTIONS", "Green"

--- a/zscript/RightInfinity/SpawnHandler.zs
+++ b/zscript/RightInfinity/SpawnHandler.zs
@@ -163,7 +163,8 @@ class RRRRWeaponsHandler : EventHandler {
 
         if (!reapermag_allowBackpacks)       backpackBlacklist.push((Class<Inventory>)('RIReapM8'));
         if (!reaperdrummag_allowBackpacks)   backpackBlacklist.push((Class<Inventory>)('RIReapD20'));
-        if (!thompsondrummag_allowBackpacks) backpackBlacklist.push((Class<Inventory>)('RITmpsD70'));
+        if (!thompsondrummag_allowBackpacks) backpackBlacklist.push((Class<Inventory>)('RITmpsD50'));
+        if (!thompsonboxmag_allowBackpacks)  backpackBlacklist.push((Class<Inventory>)('RITmpsM20'));
 
 
         //------------
@@ -204,6 +205,12 @@ class RRRRWeaponsHandler : EventHandler {
         Array<string> wep_9mmMag;
         wep_9mmMag.push('RIThompson');
         addAmmo('HD9mMag30', wep_9mmMag);
+
+        // .45 ACP Magazines
+        Array<string> wep_45ACPMag;
+        wep_45ACPMag.push('RIThompson');
+        addAmmo('RITmpsD50', wep_45ACPMag);
+        addAmmo('RITmpsM20', wep_45ACPMag);
 
 
         //------------
@@ -246,10 +253,20 @@ class RRRRWeaponsHandler : EventHandler {
         spawns_reaperdummag.push(addItemEntry('ShellBoxPickup', reaperdrummag_shellbox_spawn_bias));
         addItem('RIReapD20', spawns_reaperdummag, reaperdrummag_persistent_spawning);
 
-        // Thompson 70-round Drum
-        Array<RRRRSpawnItemEntry> spawns_thompsondrummag;
-        spawns_thompsondrummag.push(addItemEntry('ClipMagPickup', thompsondrummag_clipmag_spawn_bias));
-        addItem('RITmpsD70', spawns_thompsondrummag, thompsondrummag_persistent_spawning);
+        // Thompson 70-round 9mm Drum
+        // Array<RRRRSpawnItemEntry> spawns_thompsondrummag;
+        // spawns_thompsondrummag.push(addItemEntry('ClipMagPickup', thompsondrummag_clipmag_spawn_bias));
+        // addItem('RITmpsD70', spawns_thompsondrummag, thompsondrummag_persistent_spawning);
+
+        // Thompson 50-round .45 ACP Drum
+        Array<RRRRSpawnItemEntry> spawns_thompson45acpdrummag;
+        spawns_thompson45acpdrummag.push(addItemEntry('ClipMagPickup', thompsondrummag_clipmag_spawn_bias));
+        addItem('RITmpsD50', spawns_thompson45acpdrummag, thompsondrummag_persistent_spawning);
+
+        // Thompson 20-round .45 ACP Magazine
+        Array<RRRRSpawnItemEntry> spawns_thompson45acpboxmag;
+        spawns_thompson45acpboxmag.push(addItemEntry('ClipMagPickup', thompsonboxmag_clipmag_spawn_bias));
+        addItem('RITmpsM20', spawns_thompson45acpboxmag, thompsonboxmag_persistent_spawning);
     }
 
     // Random stuff, stores it and forces negative values just to be 0.


### PR DESCRIPTION
For now, only .45 ACP versions will spawn, as the 9mm Reproduction model feels a bit more special and intentional, rather than randomly found.  They can still be given via loadout codes.